### PR TITLE
Adds a .prettierignore file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+build/*.js
+bin/*.js
+config/*.js
+src/vendor/**/*.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,1 @@
-build/*.js
-bin/*.js
-config/*.js
 src/vendor/**/*.js


### PR DESCRIPTION
When running prettier using yarn prettier (cli version) it doesn't have any ignore rules.

This fixes #18 .