### PR TITLE
Add option to let Webpack process srcsets of picture's source element

### DIFF
--- a/build/webpackHelpers.js
+++ b/build/webpackHelpers.js
@@ -83,6 +83,9 @@ exports.getVueLoaderConfig = function(isDevelopment, eslintLoaderEnabled){
 			cssModules: {
 				localIdentName: '[local]-[hash:base64:7]',
 				camelCase: true
+			},
+			transformToRequire: {
+				source: 'srcset'
 			}
 		}
 	};


### PR DESCRIPTION
Add the option to let Webpack process the srcsets of the source element to be able to use pictures.