### PR TITLE
Fix gateway response formatter for falsy data

### DIFF
--- a/src/util/gatewayFormatter.js
+++ b/src/util/gatewayFormatter.js
@@ -9,7 +9,7 @@ export const errorFormatter = error => {
 };
 
 export const responseFormatter = response => {
-  if (response.data.data) {
+  if (response && response.data && typeof response.data.data !== 'undefined') {
     return { ...response, ...response.data };
   }
   return response;


### PR DESCRIPTION
Sometimes the data response from the API is falsy. For example when
asking for a count, the count could be 0. This makes sure the data
is still formatted properly