### PR TITLE
Use url-loader for non-icon SVG assets

### DIFF
--- a/build-tools/config/webpack/webpack.base.conf.js
+++ b/build-tools/config/webpack/webpack.base.conf.js
@@ -54,26 +54,24 @@ module.exports = {
       },
       {
         test: /\.svg$/,
-        use: [
+        oneOf: [
           {
-            loader: 'svg-inline-loader',
+            resourceQuery: /inline/,
+            use: [
+              {
+                loader: 'svg-inline-loader',
+              },
+              webpackHelpers.getSvgoLoaderConfig(),
+            ]
           },
           {
-            loader: 'svgo-loader',
-            options: {
-              plugins: [
-                { removeStyleElement: true },
-                { removeComments: true },
-                { removeDesc: true },
-                { removeUselessDefs: true },
-                { removeTitle: true },
-                { removeMetadata: true },
-                { removeComments: true },
-                { cleanupIDs: { remove: true, prefix: '' } },
-                { convertColors: { shorthex: false } },
-              ],
-            },
-          },
+            use: [
+              {
+                loader: 'url-loader',
+              },
+              webpackHelpers.getSvgoLoaderConfig(),
+            ]
+          }
         ],
       },
     ],

--- a/build-tools/config/webpack/webpackHelpers.js
+++ b/build-tools/config/webpack/webpackHelpers.js
@@ -97,3 +97,22 @@ exports.getVueLoaderConfig = function(isDevelopment) {
 
   return config;
 };
+
+exports.getSvgoLoaderConfig = function() {
+  return {
+    loader: 'svgo-loader',
+    options: {
+      plugins: [
+        { removeStyleElement: true },
+        { removeComments: true },
+        { removeDesc: true },
+        { removeUselessDefs: true },
+        { removeTitle: true },
+        { removeMetadata: true },
+        { removeComments: true },
+        { cleanupIDs: { remove: true, prefix: '' } },
+        { convertColors: { shorthex: false } },
+      ],
+    },
+  };
+};

--- a/src/component/Icon/Icon.js
+++ b/src/component/Icon/Icon.js
@@ -1,5 +1,7 @@
 import VueTypes from 'vue-types';
 
+const svgContext = require.context('asset/svg/?inline', false, /\.svg/);
+
 export default {
   name: 'Icon',
   props: {
@@ -7,8 +9,7 @@ export default {
   },
   computed: {
     icon() {
-      // eslint-disable-next-line global-require, import/no-dynamic-require
-      return require(`asset/svg/${this.name}.svg`);
+      return svgContext(`./${this.name}.svg`);
     },
   },
 };


### PR DESCRIPTION
Use a oneOf statement in webpack config to automatically switch
between using the svg-inline-loader and url-loader. By default,
use the url-loader, because this is sufficient for most cases.
For the Icon component, use the svg-inline-loader. To use the
?inline resourceQuery in Icon.js, updated the dynamic require
statement to a webpack context.

Fixes #39