### PR TITLE
Don't ignore dotfiles in CopyWebpackPlugin configuration

### DIFF
--- a/build-tools/config/webpack/webpack.prod.conf.js
+++ b/build-tools/config/webpack/webpack.prod.conf.js
@@ -108,14 +108,14 @@ const webpackConfig = merge(baseWebpackConfig, {
       {
         from: 'static',
         to: config.build.versionPath + 'static',
-        ignore: ['.*'],
+        ignore: ['.gitkeep'],
       },
     ]),
     new CopyWebpackPlugin([
       {
         from: 'staticRoot',
         to: '',
-        ignore: ['.*'],
+        ignore: ['.gitkeep'],
       },
     ]),
     new BundleAnalyzerPlugin({


### PR DESCRIPTION
We often need to copy over dotfiles from our static folders. For example, a `.htaccess` in `staticRoot`. Instead of ignoring all dotfiles, we should only ignore the `.gitkeep` file