### PR TITLE
Improve persist query parameters functionality

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -38,7 +38,7 @@ const config = {
   properties: {
     [PropertyNames.DEFAULT_LOCALE]: 'en-gb',
     [PropertyNames.AVAILABLE_LOCALES]: ['en-gb'],
-    [PropertyNames.WHITELISTED_QUERY_PARAMS]: [],
+    [PropertyNames.PERSIST_QUERY_PARAMS]: [],
   },
 };
 

--- a/src/data/enum/configNames.js
+++ b/src/data/enum/configNames.js
@@ -21,5 +21,5 @@ export const VariableNames = {
 export const PropertyNames = {
   DEFAULT_LOCALE: 'default-locale',
   AVAILABLE_LOCALES: 'available-locales',
-  WHITELISTED_QUERY_PARAMS: 'whitelisted-query-params',
+  PERSIST_QUERY_PARAMS: 'persist-query-params',
 };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -32,16 +32,19 @@ const getRouter = () => {
     });
 
     router.beforeEach((to, from, next) => {
-      const whitelistedQueryParams = configManager.getProperty(
-        PropertyNames.WHITELISTED_QUERY_PARAMS,
+      const persistQueryParams = configManager.getProperty(
+        PropertyNames.PERSIST_QUERY_PARAMS,
       );
 
       let redirect = false;
       const { ...query } = to.query;
 
-      if (whitelistedQueryParams && whitelistedQueryParams.length > 0) {
-        whitelistedQueryParams.forEach(queryParam => {
-          if (from.query[queryParam] && !query[queryParam]) {
+      if (persistQueryParams && persistQueryParams.length > 0) {
+        persistQueryParams.forEach(queryParam => {
+          if (
+            typeof from.query[queryParam] !== 'undefined' &&
+            typeof query[queryParam] === 'undefined'
+          ) {
             query[queryParam] = from.query[queryParam];
 
             redirect = true;


### PR DESCRIPTION
Rename `WHITELISTED_QUERY_PARAMS` configuration to
`PERSIST_QUERY_PARAMS`. This is more descriptive of what it does.

Replace the falsy/truthy check on the query object with undefined
checks. This will make sure the query param is also persisted for
falsy values, such as 0 or null (when you don't pass a value,
vue-router will use null)