### PR TITLE
Upgrade typescript to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "async": "^2.2.0",
     "autoprefixer": "^8.0.0",
-    "awesome-typescript-loader": "^5.0.0-1",
+    "awesome-typescript-loader": "^5.2.0",
     "babel-core": "^6.0.0",
     "babel-eslint": "^8.0.0",
     "babel-loader": "^7.1.3",
@@ -113,7 +113,7 @@
     "tslint-config-prettier": "^1.1.0",
     "tslint-loader": "^3.5.3",
     "tslint-plugin-prettier": "^1.3.0",
-    "typescript": "^2.3.4",
+    "typescript": "^3.0.1",
     "url-loader": "^1.0.1",
     "vue-loader": "^15.0.10",
     "vue-style-loader": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -580,17 +580,18 @@ autoprefixer@^8.0.0:
     postcss "^6.0.22"
     postcss-value-parser "^3.2.3"
 
-awesome-typescript-loader@^5.0.0-1:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/awesome-typescript-loader/-/awesome-typescript-loader-5.0.0.tgz#130c304ae52a60933f15d93f7629003b483fa8b1"
+awesome-typescript-loader@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/awesome-typescript-loader/-/awesome-typescript-loader-5.2.0.tgz#d7bccf4823c45096ec24da4c12a1507d276ba15a"
   dependencies:
-    chalk "^2.3.1"
+    chalk "^2.4.1"
     enhanced-resolve "^4.0.0"
     loader-utils "^1.1.0"
     lodash "^4.17.5"
     micromatch "^3.1.9"
     mkdirp "^0.5.1"
     source-map-support "^0.5.3"
+    webpack-log "^1.2.0"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -9387,9 +9388,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.3.4:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
+typescript@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 uglify-es@^3.3.4:
   version "3.3.9"
@@ -9957,7 +9958,7 @@ webpack-hot-middleware@^2.21.0:
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
 
-webpack-log@^1.0.1, webpack-log@^1.1.2:
+webpack-log@^1.0.1, webpack-log@^1.1.2, webpack-log@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
   dependencies:


### PR DESCRIPTION
This is a relatively safe upgrade. TS 3.0 has [very little breaking changes](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#typescript-30). As we have no TS in the skeleton by default, we have no breaking changes.

Also upgraded the awesome-typescript-loader to stable version