### PR TITLE
Enable strict compiler option by default in TS

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "sourceMap": true,
-    "noImplicitAny": false,
+    "strict": true,
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true,
     "target": "es2017",


### PR DESCRIPTION
This will enable the following compiler options:
 - noImplicitAny
 - noImplicitThis
 - alwaysStrict
 - strictNullChecks
 - strictFunctionTypes
 - strictPropertyInitialization

Fixes #72