### PR TITLE
Set module config for typescript to esnext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "sourceMap": true,
     "strict": true,
+    "module": "esnext",
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true,
     "target": "es2017",


### PR DESCRIPTION
This allows us to use the new es import() function to dynamically
load modules. This is the recommended way in webpack to create split
points in code, so this will be used quite frequently.