### PR TITLE
Fix eslint import resolver configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       webpack: {
-        config: 'build-tools/config/webpack/webpack.conf.dev.js',
+        config: 'build-tools/config/webpack/webpack.conf.base.js',
       },
     },
   },

--- a/build-tools/config/webpack/webpack.conf.base.js
+++ b/build-tools/config/webpack/webpack.conf.base.js
@@ -3,7 +3,8 @@ const config = require('../config');
 
 const { DEVELOPMENT, PRODUCTION } = config.buildTypes;
 
-module.exports = buildType => {
+// note: we pass a default buildType here so this file can be loaded directly from .eslintrc.js
+module.exports = (buildType = DEVELOPMENT) => {
   const generator = helpers.compose(
     [
       require('./webpack.partial.conf.devServer'),

--- a/build-tools/config/webpack/webpack.conf.dev.js
+++ b/build-tools/config/webpack/webpack.conf.dev.js
@@ -13,20 +13,20 @@ module.exports = detectPort(config.devServer.port).then(port => {
 
   if (config.devServer.autoOpenBrowser) {
     opn(`${config.devServer.useHttps ? 'https' : 'http'}://localhost:${port}`).catch(() => {});
-
-    // note: we inject this plugin here because we need access to the port
-    devWebpackConfig.plugins.push(
-      new FriendlyErrorsWebpackPlugin({
-        compilationSuccessInfo: {
-          messages: [
-            `Your application is running here: ${
-              config.devServer.useHttps ? 'https' : 'http'
-            }://localhost:${port}`,
-          ],
-        },
-      }),
-    );
   }
+
+  // note: we inject this plugin here because we need access to the port
+  devWebpackConfig.plugins.push(
+    new FriendlyErrorsWebpackPlugin({
+      compilationSuccessInfo: {
+        messages: [
+          `Your application is running here: ${
+            config.devServer.useHttps ? 'https' : 'http'
+            }://localhost:${port}`,
+        ],
+      },
+    }),
+  );
 
   return devWebpackConfig;
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-skeleton",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A Vue Skeleton",
   "author": "Hendrik-Jan de Harder <hendrik-jan@mediamonks.com>",
   "license": "MIT",


### PR DESCRIPTION
The eslint import resolver configuration points to the webpack.conf.dev.js file. This is problematic because that file contains additional code to detect the port to run under and automatically opens your browser. 

This issue does not arise in an empty vue-skeleton project, because the import resolver is never triggered there. Once you start doing imports that need to be resolved using webpack (like imports to .ts files without an extension) this issue is triggered. This causes the linter to never complete.

Also fixed a small error I found in webpack.conf.dev.js where a statement was in the wrong location