### PR TITLE
remove defaulted :local in sg-templates and changed to name of component

### DIFF
--- a/build-tools/template/component/{name_pc}/{name_pc}.scss
+++ b/build-tools/template/component/{name_pc}/{name_pc}.scss
@@ -1,4 +1,4 @@
 /* stylelint-disable-next-line block-no-empty */
-:local {
+.{{name_sc}} {
 
 }

--- a/build-tools/template/component/{name_pc}/{name_pc}.vue
+++ b/build-tools/template/component/{name_pc}/{name_pc}.vue
@@ -2,7 +2,7 @@
 <script src="./{{name_pc}}.js"></script>
 
 <template>
-  <div>
+  <div :class="[$style.{{name_cc}}]">
     <h2>{{name_pc}}</h2>
   </div>
 </template>

--- a/build-tools/template/page/{name_pc}/{name_pc}.scss
+++ b/build-tools/template/page/{name_pc}/{name_pc}.scss
@@ -1,4 +1,4 @@
 /* stylelint-disable-next-line block-no-empty */
-:local {
+.{{name_sc}} {
 
 }

--- a/build-tools/template/page/{name_pc}/{name_pc}.vue
+++ b/build-tools/template/page/{name_pc}/{name_pc}.vue
@@ -2,7 +2,7 @@
 <script src="./{{name_pc}}.js"></script>
 
 <template>
-  <div>
+  <div :class="[$style.{{name_cc}}]">
     <h2>{{name_pc}}</h2>
   </div>
 </template>


### PR DESCRIPTION
- removed :local in our stylesheet because the default styles are :local already (reduces nesting)
- standardised our naming of the root-element to the name of the component and already applied it to the template.