### PR TITLE
Disable tslint strict-boolean-expressions

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -12,13 +12,7 @@
     "no-console": true,
     "prefer-array-literal": [true, { "allow-type-parameters": true }],
     "variable-name": [true, "allow-pascal-case"],
-    "strict-boolean-expressions": [
-      true,
-      "allow-null-union",
-      "allow-undefined-union",
-      "allow-string",
-      "allow-number"
-    ],
+    "strict-boolean-expressions": false,
     "import-name": false,
     "prettier": true
   }


### PR DESCRIPTION
I notice that myself and other devs often run into this rule failing. It's not always obvious how to make the linter happy, and the fix sometimes looks somewhat convoluted. I am also not entirely convinced that this rule is very useful, but if you think otherwise please leave a comment. It seems that tslint-config-airbnb has also removed the rule due to there being some issues with it.