### PR TITLE
Add "skeleton" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "vue-skeleton",
   "version": "1.8.2",
+  "skeleton": {
+    "name": "vue-skeleton",
+    "version": "1.8.2"
+  },
   "description": "A Vue Skeleton",
   "author": "Hendrik-Jan de Harder <hendrik-jan@mediamonks.com>",
   "license": "MIT",


### PR DESCRIPTION
Create a "skeleton" field that mirrors the "name" and "version" properties.

The reasoning behind this: when you create your own project, you should be able to change the "version" and "name" field in `package.json` to reflect your project rather than `vue-skeleton`. If we do that however, we lose information about which skeleton version the project was originally started with.