### PR TITLE
add universal path alias in webpack.partial.conf.resolve

### DIFF
--- a/build-tools/config/webpack/webpack.partial.conf.resolve.js
+++ b/build-tools/config/webpack/webpack.partial.conf.resolve.js
@@ -8,6 +8,7 @@ module.exports = ({ config }) => webpackConfig => ({
       modernizr$: path.join(config.projectRoot, '.modernizrrc'),
       TweenLite: path.resolve(config.projectRoot, 'node_modules/gsap/src/uncompressed/TweenLite'),
       asset: path.resolve(config.projectRoot, 'src/asset'),
+      '@': path.resolve(config.projectRoot, 'src'),
     },
   },
 });


### PR DESCRIPTION
Always wanted to add this to the skeleton. It is useful when you are deep in the folder structure. It's more powerful with typescript.