### PR TITLE
Add abiltity to run Vue Skeleton under a hash based strict CSP

### DIFF
--- a/build-tools/config/webpack/webpack.conf.base.js
+++ b/build-tools/config/webpack/webpack.conf.base.js
@@ -26,6 +26,6 @@ module.exports = (buildType = DEVELOPMENT) => {
     // single configuration properties go here
     // object go into a separate file (e.g. webpack.partial.conf.entry.js)
     mode: buildType === PRODUCTION ? 'production' : 'development',
-    devtool: buildType === DEVELOPMENT ? 'cheap-module-eval-source-map' : false,
+    devtool: buildType === DEVELOPMENT ? 'cheap-module-source-map' : false,
   });
 };

--- a/build-tools/config/webpack/webpack.partial.conf.plugins.js
+++ b/build-tools/config/webpack/webpack.partial.conf.plugins.js
@@ -45,7 +45,7 @@ module.exports = ({ config, isDevelopment, buildType }) => (webpackConfig) => {
         ? {
             filename: config.devServer.indexHtml,
             template: 'index.html',
-            inject: true,
+            inject: false,
             version: config.dist.versionPath,
             minify: {
               removeComments: true,
@@ -57,7 +57,7 @@ module.exports = ({ config, isDevelopment, buildType }) => (webpackConfig) => {
             filename: 'index.html',
             template: 'index.html',
             version: '/',
-            inject: true,
+            inject: false,
             cache: true,
           },
     ),

--- a/build-tools/csp/script-loader.js
+++ b/build-tools/csp/script-loader.js
@@ -1,3 +1,8 @@
+/**
+ * script-loader source, minified version located in index.html.
+ * this script is used for loading other application scripts within its own domain.
+ * the syntax is compatible with older browsers
+ */
 (function() {
   var scripts = document.querySelectorAll('html > head > meta[name="app-script"]');
 

--- a/build-tools/csp/script-loader.js
+++ b/build-tools/csp/script-loader.js
@@ -1,0 +1,17 @@
+(function() {
+  var scripts = document.querySelectorAll('html > head > meta[name="app-script"]');
+
+  for (var i = 0; i < scripts.length; i++) {
+    var path = scripts[i].getAttribute('content');
+    var script = document.createElement('script');
+    script.src = path;
+
+    var domain = script.src.substr(0, window.location.origin.length);
+
+    if (domain !== window.location.origin) {
+      window.console && console.error('[ScriptLoader] Cannot load ' + path + '.');
+    } else {
+      document.body.appendChild(script);
+    }
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <% } %>
 
     <% if(process.env.NODE_ENV === 'development') { %>
-      <meta http-equiv="Content-Security-Policy" content="script-src 'sha256-y6zSYDRnnvPXsdyPJkSTJ25talbGpofNceZQ0NWVil4=' 'sha256-T6VpZaIBkbQNokSAmOCA6btCvzSmdUvUrNUtK9IsMMs=' 'strict-dynamic' https: http: 'unsafe-inline'; object-src 'none'; base-uri 'none';">
+      <meta http-equiv="Content-Security-Policy" content="script-src 'sha256-+OVgFCkyF2/rZ6qyfsNnIisCRI6dtMZw3w0Y4xiYagw=' 'strict-dynamic' https: http: 'unsafe-inline'; object-src 'none'; base-uri 'none';">
     <% } %>
 
     <% for (var chunk in htmlWebpackPlugin.files.css) { %>

--- a/index.html
+++ b/index.html
@@ -5,14 +5,18 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no" />
 
+    <!--
+      Uncomment and adjust content for webpack:public-path content parameter to override webpack (runtime) publicPath
+      <meta name="webpack:public-path" content="<%= process.env.PUBLIC_PATH %>" />
+      <meta name="app-script" content="<%= process.env.PUBLIC_PATH %><%= process.env.VERSIONED_STATIC_ROOT %>js/webpack.path.js" />
+    -->
+    <% for (var chunk in htmlWebpackPlugin.files.js) { %>
+      <meta name="app-script" content="<%= htmlWebpackPlugin.files.js[chunk]%>" />
+    <% } %>
+
     <% if(process.env.NODE_ENV === 'development') { %>
       <meta http-equiv="Content-Security-Policy" content="script-src 'sha256-y6zSYDRnnvPXsdyPJkSTJ25talbGpofNceZQ0NWVil4=' 'sha256-T6VpZaIBkbQNokSAmOCA6btCvzSmdUvUrNUtK9IsMMs=' 'strict-dynamic' https: http: 'unsafe-inline'; object-src 'none'; base-uri 'none';">
     <% } %>
-
-    <!--
-      Uncomment and adjust content override webpack publicPath
-      <meta name="webpack:public-path" content="/" />
-    -->
 
     <% for (var chunk in htmlWebpackPlugin.files.css) { %>
       <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[chunk]%>" />
@@ -23,17 +27,6 @@
   <body>
     <div id="app"></div>
 
-    <!--
-      Uncomment to enable overriding webpack public path
-      <div data-app-src="<%= process.env.PUBLIC_PATH %><%= process.env.VERSIONED_STATIC_ROOT %>js/webpack.path.js" data-type="app"></div>
-    -->
-
-    <% for (var chunk in htmlWebpackPlugin.files.js) { %>
-    <div data-app-src="<%= htmlWebpackPlugin.files.js[chunk]%>"
-    <% if(htmlWebpackPlugin.files.js[chunk].includes("polyfill")) { %> data-type="polyfill" <% } else{ %> data-type="app"<% } %>
-    ></div>
-    <% } %>
-
-    <script>"use strict";!function(){for(var t=document.querySelectorAll("[data-app-src]"),e=0;e<t.length;e++){var r=t[e].dataset.type,a=t[e].dataset.appSrc;if("/"!==a[0])return;var c=document.createElement("script");c.src=a,"polyfill"===r&&c.setAttribute("noModule",""),document.body.appendChild(c)}}()</script>
+    <script>!function(){for(var o=document.querySelectorAll('html > head > meta[name="app-script"]'),t=0;t<o.length;t++){var e=o[t].getAttribute("content"),n=document.createElement("script");n.src=e,n.src.substr(0,window.location.origin.length)!==window.location.origin?window.console&&console.error("[ScriptLoader] Cannot load "+e+"."):document.body.appendChild(n)}}()</script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,15 +5,35 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no" />
 
-    <title>Vue Skeleton</title>
+    <% if(process.env.NODE_ENV === 'development') { %>
+      <meta http-equiv="Content-Security-Policy" content="script-src 'sha256-y6zSYDRnnvPXsdyPJkSTJ25talbGpofNceZQ0NWVil4=' 'sha256-T6VpZaIBkbQNokSAmOCA6btCvzSmdUvUrNUtK9IsMMs=' 'strict-dynamic' https: http: 'unsafe-inline'; object-src 'none'; base-uri 'none';">
+    <% } %>
 
-    <script>
-      // enable to override webpacks publicPath
-      // var webpackPublicPath = '/';
-    </script>
+    <!--
+      Uncomment and adjust content override webpack publicPath
+      <meta name="webpack:public-path" content="/" />
+    -->
+
+    <% for (var chunk in htmlWebpackPlugin.files.css) { %>
+      <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[chunk]%>" />
+    <% } %>
+
+    <title>Vue Skeleton</title>
   </head>
   <body>
     <div id="app"></div>
-    <!-- built files will be auto injected -->
+
+    <!--
+      Uncomment to enable overriding webpack public path
+      <div data-app-src="<%= process.env.PUBLIC_PATH %><%= process.env.VERSIONED_STATIC_ROOT %>js/webpack.path.js" data-type="app"></div>
+    -->
+
+    <% for (var chunk in htmlWebpackPlugin.files.js) { %>
+    <div data-app-src="<%= htmlWebpackPlugin.files.js[chunk]%>"
+    <% if(htmlWebpackPlugin.files.js[chunk].includes("polyfill")) { %> data-type="polyfill" <% } else{ %> data-type="app"<% } %>
+    ></div>
+    <% } %>
+
+    <script>"use strict";!function(){for(var t=document.querySelectorAll("[data-app-src]"),e=0;e<t.length;e++){var r=t[e].dataset.type,a=t[e].dataset.appSrc;if("/"!==a[0])return;var c=document.createElement("script");c.src=a,"polyfill"===r&&c.setAttribute("noModule",""),document.body.appendChild(c)}}()</script>
   </body>
 </html>

--- a/static/js/webpack.path.js
+++ b/static/js/webpack.path.js
@@ -1,0 +1,5 @@
+(function setPublicPath(publicPathMeta) {
+  if (publicPathMeta) {
+    window.webpackPublicPath = publicPathMeta.getAttribute('content');
+  }
+})(document.querySelector('meta[name="webpack:public-path"]'));


### PR DESCRIPTION
### Strict CSP preperations

These changes allow Vue Skeleton run under a strict Content Security Policy. The strategy (script-loader) in this PR should be applied throughout other frameworks Muban / Muban-Skeleton / React (In the works).

The strict CSP will be applied in development mode, which should prevent "surprises" on build time. However strict CSP It isn't automatically enabled whenever running a build, so it's an opt-in kind of solution. The CSP header as listed in the `<meta http-equiv="Content-Security-Policy" ... />` should be added to server response as well. 

It would be great if we can have additional review check the source of script-loader which is the minified snippet in the `index.html`.

### The strategy
As our builds are dynamic / cache busting, it's impossible to supply one specific script hash. Using the loader script below we can enforce / allowing loading scripts from our own domain. The downside is that we need to trust the loader-script not to load malicious files. The way to enforce that is to only allow loading those scripts from the hosted domain.